### PR TITLE
handle bad cookie keys better.  Logging if any other error occurs

### DIFF
--- a/beaker_session_jwt.py
+++ b/beaker_session_jwt.py
@@ -93,11 +93,17 @@ class JWTCookieSession(CookieSession):
             cookiedict[k] = v
 
         try:
+            # limit to only the key we care about, to avoid any problematic other cookies
+            if self.key in cookiedict:
+                cookiedict_our_key_only = {self.key: cookiedict[self.key]}
+            else:
+                cookiedict_our_key_only = {}
             # BaseCookie instead of SimpleCookie to avoid extra " when using write_original_format option
             self.cookie = BaseCookie(
-                input=cookiedict,
+                input=cookiedict_our_key_only,
             )
-        except CookieError:
+        except CookieError as e:
+            log.warning(f'Cookie parsing error: {e} in {cookieheader}')
             self.cookie = BaseCookie(
                 input=None,
             )

--- a/test.py
+++ b/test.py
@@ -1,3 +1,4 @@
+import re
 from datetime import datetime, timedelta
 from unittest.mock import MagicMock
 
@@ -138,6 +139,15 @@ def test_bad_cookie_key_with_session_cookie():
     req['cookie'] = 'foo[1]=bar; beaker.session.id=' + jwt_secret1_bson_date
     jcs = JWTCookieSession(req, jwt_secret_keys='secret1', timeout=10)
     assert 'last' in jcs
+
+
+def test_bad_session_cookie(caplog):
+    # not likely anyone would actually set their session KEY to some invalid name
+    # but setting up this test to get full coverage on error handling
+    req = FakeReq()
+    req['cookie'] = 'session[invalid]=asdf'
+    JWTCookieSession(req, jwt_secret_keys='x', key='session[invalid]')
+    assert caplog.records[0].message == "Cookie parsing error: Illegal key 'session[invalid]' in session[invalid]=asdf"
 
 
 def test_invalid_existing_cookie():

--- a/test.py
+++ b/test.py
@@ -126,9 +126,16 @@ def test_bad_existing_cookie():
     jcs._encrypt_data({'hi': 'you'})
 
 
-def test_bad_cookie_with_session_cookie():
+def test_bad_cookie_value_with_session_cookie():
     req = FakeReq()
     req['cookie'] = 'foo={"bar":1,"a":"a"}; beaker.session.id=' + jwt_secret1_bson_date
+    jcs = JWTCookieSession(req, jwt_secret_keys='secret1', timeout=10)
+    assert 'last' in jcs
+
+
+def test_bad_cookie_key_with_session_cookie():
+    req = FakeReq()
+    req['cookie'] = 'foo[1]=bar; beaker.session.id=' + jwt_secret1_bson_date
     jcs = JWTCookieSession(req, jwt_secret_keys='secret1', timeout=10)
     assert 'last' in jcs
 
@@ -266,7 +273,6 @@ def test_nonreserializable_is_logged(caplog):
 
     resp = old_app.get('/')
     assert 'current value is: 1' in resp.text
-    print(resp.text)
     new_app.set_cookie('beaker.session.id', old_app.cookies['beaker.session.id'])
     resp = new_app.get('/skip-date')  # load a page without re-adding it since that'll cause more problems
     assert 'original format cookie (pickle) loaded with fields that cannot be serialized' in caplog.records[0].message


### PR DESCRIPTION
Original BaseCookie parsing of a string would handle invalid keys and ignore them. But since we're doing pre-parsing and providing a dict to BaseCookie, it was raising an error on a bad key